### PR TITLE
Changing minimal library requirement from 1.2.2 to 1.2.0.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,5 @@ dependencies:
   - numpy
   - scipy
   - pandas
-  - SimpleITK>=1.2.2
+  - SimpleITK>=1.2.0
     


### PR DESCRIPTION
The 1.2.2 build for anaconda on OSX is not working due to toolchain
issues in anaconda.